### PR TITLE
Fixed lights cache not being reset on mtx changing operations

### DIFF
--- a/f3dex3.s
+++ b/f3dex3.s
@@ -3023,6 +3023,7 @@ G_POPMTX_handler:
     lw      $2, OSTask + OSTask_dram_stack  // Top of the stack
     sub     cmd_w1_dram, $11, cmd_w1_dram   // Decrease pointer by amount in command
     sub     $1, cmd_w1_dram, $2             // Is it still valid / within the stack?
+    sb      $zero, dirLightsXfrmValid       // Mark lights as needing recompute
     bgez    $1, @@skip                      // If so, skip the failsafe
      sb     $zero, mITValid                 // Mark matrix as needing recompute
     move    cmd_w1_dram, $2                 // Use the top of the stack as the new pointer
@@ -3051,6 +3052,7 @@ G_MTX_handler:
     lw      cmd_w1_dram, (inputBufferEnd - 4)(inputBufferPos) // Load command word 1 again
 load_mtx:
     add     $7, $7, $2        // Add the load type to the command byte in $7, selects the return address based on whether the matrix needs multiplying or just loading
+    sb      $zero, dirLightsXfrmValid
     sb      $zero, mITValid
 G_MOVEMEM_handler:
     jal     segmented_to_physical   // convert the memory address cmd_w1_dram to a virtual one


### PR DESCRIPTION
Stopgap fix for issue where lights cache is not getting reset when mtx updates do not invalidate dirLights.

Check comment https://github.com/Mr-Wiseguy/f3dex2/blob/master/f3dex2.s#L298-L300 mvpValid is setup in such a way that https://github.com/Mr-Wiseguy/f3dex2/blob/master/f3dex2.s#L2218 and https://github.com/Mr-Wiseguy/f3dex2/blob/master/f3dex2.s#L2276 can reset dirLightsXfrmValid and mITValid/mvpValid at the same time with one SW. Memory layout in EX3 is changed so this is no longer possible so I have added explicit SB for dirLightsXfrmValid to workaround this.